### PR TITLE
feature: added env to browser (mirroring the mocha-play env)

### DIFF
--- a/src/run-tests.ts
+++ b/src/run-tests.ts
@@ -53,7 +53,8 @@ export async function runTests(testFiles: string[], options: IRunTestsOptions = 
             MOCHA_REPORTER: options.reporter ?? 'spec',
             MOCHA_TIMEOUT: options.timeout ?? 2000,
             MOCHA_GREP: options.grep ? `${JSON.stringify(options.grep)}` : 'null',
-            MOCHA_ITERATE: options.iterate
+            MOCHA_ITERATE: options.iterate,
+            MOCHA_ENV: JSON.stringify(process.env)
           },
         }),
       ],

--- a/static/index.ejs
+++ b/static/index.ejs
@@ -24,7 +24,7 @@
       const timeout = <%= MOCHA_TIMEOUT %>;
       const grep = <%= MOCHA_GREP %>;
       const iterate = <%= MOCHA_ITERATE %>;
-      const env = <%= MOCHA_ENV %>;
+      window.env = <%= MOCHA_ENV %>;
 
       mocha.setup({ ui, reporter, color, timeout, grep });
 

--- a/static/index.ejs
+++ b/static/index.ejs
@@ -24,6 +24,7 @@
       const timeout = <%= MOCHA_TIMEOUT %>;
       const grep = <%= MOCHA_GREP %>;
       const iterate = <%= MOCHA_ITERATE %>;
+      const env = <%= MOCHA_ENV %>;
 
       mocha.setup({ ui, reporter, color, timeout, grep });
 

--- a/test/fixtures/env.unit.js
+++ b/test/fixtures/env.unit.js
@@ -1,0 +1,7 @@
+describe('env', () => {
+  it('passes the env to the test runner html', () => {
+      if (env.mocha_env_test !== 'true') {
+        throw new Error(`window.MOCHA_ENV.mocha_env_test is not true`)
+      }
+  });
+});

--- a/test/fixtures/env.unit.js
+++ b/test/fixtures/env.unit.js
@@ -1,6 +1,6 @@
 describe('env', () => {
   it('passes the env to the test runner html', () => {
-      if (env.mocha_env_test !== 'true') {
+      if (window.env.mocha_env_test !== 'true') {
         throw new Error(`window.MOCHA_ENV.mocha_env_test is not true`)
       }
   });

--- a/test/mocha-play.spec.ts
+++ b/test/mocha-play.spec.ts
@@ -148,4 +148,12 @@ describe('mocha-play', function () {
     expect(output).to.include('9 passing');
     expect(status).to.equal(0);
   })
+ 
+  it('sets env in the browser to be process.env', ()=>{
+    process.env['mocha_env_test'] = 'true';
+    const { output, status } = runMochaPlay({ args: ['./env.unit.js'] });
+    expect(output).to.include('Found 1 test files');
+    expect(output).to.include('1 passing');
+    expect(status).to.equal(0);
+  })
 });


### PR DESCRIPTION
the idea is to have the env readable in the browser so we can do thing like extends the wait time in CI