### PR TITLE
fix: update playwright version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "mocha-play": "bin/mocha-play.js"
       },
       "devDependencies": {
-        "@playwright/browser-chromium": "^1.38.1",
+        "@playwright/browser-chromium": "^1.39.0",
         "@ts-tools/webpack-loader": "^5.0.2",
         "@types/chai": "^4.3.8",
         "@types/express": "^4.17.19",
@@ -33,7 +33,7 @@
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-no-only-tests": "^3.1.0",
         "mocha": "^10.2.0",
-        "playwright": "^1.38.1",
+        "playwright": "^1.39.0",
         "prettier": "^3.0.3",
         "rimraf": "^5.0.5",
         "typescript": "~5.2.2",
@@ -44,7 +44,7 @@
       },
       "peerDependencies": {
         "mocha": ">=7",
-        "playwright": ">=1.38.0",
+        "playwright": ">=1.39.0",
         "webpack": "^5.0.0"
       }
     },
@@ -284,13 +284,13 @@
       }
     },
     "node_modules/@playwright/browser-chromium": {
-      "version": "1.38.1",
-      "resolved": "https://registry.npmjs.org/@playwright/browser-chromium/-/browser-chromium-1.38.1.tgz",
-      "integrity": "sha512-HRhcBGtk1XaGAQjOben/04PNHxWAY3DBHT97egraR5lx5SQSLOREIiYu/j7WlvQBz4QJP+XL2JsvoxFBJfXmAw==",
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/@playwright/browser-chromium/-/browser-chromium-1.39.0.tgz",
+      "integrity": "sha512-s1WPO0qOE7PIZcdcJEd4CHQgXf9rOwy00Den8DsXTI26n/Eqa2HzFSbLRE1Eh2nIJZFSGyKLbopHR0HkT8ClZw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "playwright-core": "1.38.1"
+        "playwright-core": "1.39.0"
       },
       "engines": {
         "node": ">=16"
@@ -3574,12 +3574,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.38.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.38.1.tgz",
-      "integrity": "sha512-oRMSJmZrOu1FP5iu3UrCx8JEFRIMxLDM0c/3o4bpzU5Tz97BypefWf7TuTNPWeCe279TPal5RtPPZ+9lW/Qkow==",
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.39.0.tgz",
+      "integrity": "sha512-naE5QT11uC/Oiq0BwZ50gDmy8c8WLPRTEWuSSFVG2egBka/1qMoSqYQcROMT9zLwJ86oPofcTH2jBY/5wWOgIw==",
       "dev": true,
       "dependencies": {
-        "playwright-core": "1.38.1"
+        "playwright-core": "1.39.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -3592,9 +3592,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.38.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.38.1.tgz",
-      "integrity": "sha512-tQqNFUKa3OfMf4b2jQ7aGLB8o9bS3bOY0yMEtldtC2+spf8QXG9zvXLTXUeRsoNuxEYMgLYR+NXfAa1rjKRcrg==",
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.39.0.tgz",
+      "integrity": "sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==",
       "dev": true,
       "bin": {
         "playwright-core": "cli.js"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "peerDependencies": {
     "mocha": ">=7",
-    "playwright": ">=1.38.0",
+    "playwright": ">=1.39.0",
     "webpack": "^5.0.0"
   },
   "dependencies": {
@@ -36,7 +36,7 @@
     "webpack-dev-middleware": "^6.1.1"
   },
   "devDependencies": {
-    "@playwright/browser-chromium": "^1.38.1",
+    "@playwright/browser-chromium": "^1.39.0",
     "@ts-tools/webpack-loader": "^5.0.2",
     "@types/chai": "^4.3.8",
     "@types/express": "^4.17.19",
@@ -48,7 +48,7 @@
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-no-only-tests": "^3.1.0",
     "mocha": "^10.2.0",
-    "playwright": "^1.38.1",
+    "playwright": "^1.39.0",
     "prettier": "^3.0.3",
     "rimraf": "^5.0.5",
     "typescript": "~5.2.2",


### PR DESCRIPTION
Bumps both `@playwright/browser-chromium` and `playwright` simultaneously;

Closes #543
Closes #542