### PR TITLE
fix(infra): fix semver state by reverting "refactor!: make playwright a peerDep (#525)"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20, 18]
+        node-version: [20, 18, 16]
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
       - uses: actions/checkout@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "find-up": "^6.3.0",
         "glob": "^10.3.10",
         "html-webpack-plugin": "^5.5.3",
+        "playwright-core": "^1.38.0",
         "webpack-dev-middleware": "^6.1.1"
       },
       "bin": {
@@ -33,7 +34,6 @@
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-no-only-tests": "^3.1.0",
         "mocha": "^10.2.0",
-        "playwright": "^1.39.0",
         "prettier": "^3.0.3",
         "rimraf": "^5.0.5",
         "typescript": "~5.2.2",
@@ -44,7 +44,6 @@
       },
       "peerDependencies": {
         "mocha": ">=7",
-        "playwright": ">=1.39.0",
         "webpack": "^5.0.0"
       }
     },
@@ -3573,29 +3572,10 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/playwright": {
-      "version": "1.39.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.39.0.tgz",
-      "integrity": "sha512-naE5QT11uC/Oiq0BwZ50gDmy8c8WLPRTEWuSSFVG2egBka/1qMoSqYQcROMT9zLwJ86oPofcTH2jBY/5wWOgIw==",
-      "dev": true,
-      "dependencies": {
-        "playwright-core": "1.39.0"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
     "node_modules/playwright-core": {
       "version": "1.39.0",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.39.0.tgz",
       "integrity": "sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==",
-      "dev": true,
       "bin": {
         "playwright-core": "cli.js"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@types/chai": "^4.3.8",
         "@types/express": "^4.17.19",
         "@types/mocha": "^10.0.2",
-        "@types/node": "18",
+        "@types/node": "16",
         "@typescript-eslint/eslint-plugin": "^6.7.5",
         "chai": "^4.3.10",
         "eslint": "^8.51.0",
@@ -40,7 +40,7 @@
         "webpack": "^5.89.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=16"
       },
       "peerDependencies": {
         "mocha": ">=7",
@@ -424,9 +424,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.18.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.1.tgz",
-      "integrity": "sha512-3G42sxmm0fF2+Vtb9TJQpnjmP+uKlWvFa8KoEGquh4gqRmoUG/N0ufuhikw6HEsdG2G2oIKhog1GCTfz9v5NdQ=="
+      "version": "16.18.58",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.58.tgz",
+      "integrity": "sha512-YGncyA25/MaVtQkjWW9r0EFBukZ+JulsLcVZBlGUfIb96OBMjkoRWwQo5IEWJ8Fj06Go3GHw+bjYDitv6BaGsA=="
     },
     "node_modules/@types/qs": {
       "version": "6.9.8",
@@ -3581,20 +3581,6 @@
       },
       "engines": {
         "node": ">=16"
-      }
-    },
-    "node_modules/playwright/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   },
   "peerDependencies": {
     "mocha": ">=7",
-    "playwright": ">=1.39.0",
     "webpack": "^5.0.0"
   },
   "dependencies": {
@@ -33,6 +32,7 @@
     "find-up": "^6.3.0",
     "glob": "^10.3.10",
     "html-webpack-plugin": "^5.5.3",
+    "playwright-core": "^1.38.0",
     "webpack-dev-middleware": "^6.1.1"
   },
   "devDependencies": {
@@ -48,7 +48,6 @@
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-no-only-tests": "^3.1.0",
     "mocha": "^10.2.0",
-    "playwright": "^1.39.0",
     "prettier": "^3.0.3",
     "rimraf": "^5.0.5",
     "typescript": "~5.2.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@types/chai": "^4.3.8",
     "@types/express": "^4.17.19",
     "@types/mocha": "^10.0.2",
-    "@types/node": "18",
+    "@types/node": "16",
     "@typescript-eslint/eslint-plugin": "^6.7.5",
     "chai": "^4.3.10",
     "eslint": "^8.51.0",
@@ -66,7 +66,7 @@
     "singleQuote": true
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=16"
   },
   "license": "MIT",
   "repository": "git@github.com:wixplosives/mocha-play.git"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,7 @@ import { pathToFileURL, URL } from 'url';
 import { Command } from 'commander';
 import { globSync } from 'glob';
 import type webpack from 'webpack';
-import type playwright from 'playwright';
+import type playwright from 'playwright-core';
 import { findUpSync } from 'find-up';
 import { runTests } from './run-tests.js';
 

--- a/src/hook-page-console.ts
+++ b/src/hook-page-console.ts
@@ -1,4 +1,4 @@
-import type playwright from 'playwright';
+import type playwright from 'playwright-core';
 
 /**
  * Hooks the console of a `playwright.Page` to Node's console,

--- a/src/run-tests.ts
+++ b/src/run-tests.ts
@@ -1,7 +1,7 @@
 import { createRequire } from 'module';
 import path from 'path';
 import express from 'express';
-import playwright from 'playwright';
+import playwright from 'playwright-core';
 import webpack from 'webpack';
 import webpackDevMiddleware from 'webpack-dev-middleware';
 import HtmlWebpackPlugin from 'html-webpack-plugin';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -11,8 +11,8 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2022",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    "lib": ["es2022", "dom"],                            /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    "target": "es2020",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "lib": ["es2020", "dom"],                            /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
     // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */


### PR DESCRIPTION
This reverts commits `af4df50a` and `6695ae3` that contain breaking changes and require major version bump, but were included into `v6.0.1`. 

This is done for the release of `v6.0.2` that will be semver-compatible, and `v7.0.0` could be released with revert of this revert